### PR TITLE
fixed parameter file of slam_toolbox(ROS2 Foxy)

### DIFF
--- a/config/mapper_params_online_sync.yaml
+++ b/config/mapper_params_online_sync.yaml
@@ -1,6 +1,6 @@
 # Reference: https://github.com/SteveMacenski/slam_toolbox/blob/foxy-devel/config/mapper_params_online_async.yaml
 
-slam_toolbox:
+sync_slam_toolbox_node:
   ros__parameters:
 
     # Plugin params


### PR DESCRIPTION
I fixed to load parameter file of slam_toolbox for ROS2 Foxy.