### PR TITLE
Suppress localization drift in jazzy 

### DIFF
--- a/launch/utils/gz.launch.py
+++ b/launch/utils/gz.launch.py
@@ -93,6 +93,7 @@ def generate_launch_description():
             # ros <-> gz sync : cmd_vel, odom
             "/cmd_vel@geometry_msgs/msg/Twist@gz.msgs.Twist",
             "/odom@nav_msgs/msg/Odometry@gz.msgs.Odometry",
+            "/odom_truth@nav_msgs/msg/Odometry@gz.msgs.Odometry",
         ],
         condition=UnlessCondition(use_ros2_control)
     )
@@ -112,6 +113,7 @@ def generate_launch_description():
             # ros <-> gz sync : cmd_vel, odom
             "/cmd_vel@geometry_msgs/msg/TwistStamped@gz.msgs.Twist",
             "/odom@nav_msgs/msg/Odometry@gz.msgs.Odometry",
+            "/odom_truth@nav_msgs/msg/Odometry@gz.msgs.Odometry",
         ],
         condition=IfCondition(use_ros2_control)
     )

--- a/launch/utils/robot_description.launch.py
+++ b/launch/utils/robot_description.launch.py
@@ -46,21 +46,10 @@ def generate_launch_description():
             }
         ]
     )
-
-    joint_state_publisher = Node(
-        package='joint_state_publisher',
-        executable='joint_state_publisher',
-        name='joint_state_publisher',
-        output='screen',
-        parameters=[
-            {'use_sim_time': use_sim_time}
-        ]
-    )
     return LaunchDescription([
         declare_use_sim_time,
         declare_use_ros2_control,
         declare_gazebo,
 
         robot_state_publisher,
-        joint_state_publisher,
     ])

--- a/robots/vmegarover.urdf.xacro
+++ b/robots/vmegarover.urdf.xacro
@@ -17,13 +17,17 @@
   <!-- Wheel -->
   <!-- Right Wheel -->
   <xacro:wheel_v0 prefix="right" parent="base_link">
-    <origin xyz="0 -0.142 0.074742"/>
-    <axis xyz="0 1 0"/>
+    <!-- Using M_PI causes an error in odometry. -->
+    <!-- <origin xyz="0 -0.142 0.074742" rpy="-${M_PI/2} 0 0"/> -->
+    <origin xyz="0 -0.142 0.074742" rpy="-1.57 0 0"/>
+    <axis xyz="0 0 1"/>
   </xacro:wheel_v0>
   <!-- Left Wheel -->
   <xacro:wheel_v0 prefix="left" parent="base_link">
-    <origin xyz="0 0.142 0.074742" rpy="0 0 ${M_PI}" />
-    <axis xyz="0 -1 0"/>
+    <!-- Using M_PI causes an error in odometry. -->
+    <!-- <origin xyz="0 0.142 0.074742" rpy="-${M_PI/2} 0 0"/> -->
+    <origin xyz="0 0.142 0.074742" rpy="-1.57 0 0"/>
+    <axis xyz="0 0 1"/>
   </xacro:wheel_v0>
 
   <!-- Front LRF -->

--- a/robots/vmegarover.urdf.xacro
+++ b/robots/vmegarover.urdf.xacro
@@ -139,6 +139,23 @@
       </plugin>
     </gazebo>
   </xacro:unless>
+  <!-- Ground Truth Odometry -->
+  <gazebo>
+    <plugin
+      filename="gz-sim-odometry-publisher-system"
+      name="gz::sim::systems::OdometryPublisher">
+      <odom_topic>odom_truth</odom_topic>
+      <odom_frame>odom</odom_frame>
+      <odom_publish_frequency>50</odom_publish_frequency>
+      <robot_base_frame>base_footprint</robot_base_frame>
+
+      <!-- Ground Truth TF
+            When commenting in, disable TF on the diff drive controller.
+      -->
+      <!-- <publish_tf>true</publish_tf> -->
+      <!-- <tf_topic>/tf</tf_topic> -->
+    </plugin>
+  </gazebo>
 
   <!-- Base -->
   <xacro:base_gazebo_v0/>

--- a/robots/vmegarover.urdf.xacro
+++ b/robots/vmegarover.urdf.xacro
@@ -17,12 +17,12 @@
   <!-- Wheel -->
   <!-- Right Wheel -->
   <xacro:wheel_v0 prefix="right" parent="base_link">
-    <origin xyz="0 -0.14199 0.074742"/>
+    <origin xyz="0 -0.142 0.074742"/>
     <axis xyz="0 1 0"/>
   </xacro:wheel_v0>
   <!-- Left Wheel -->
   <xacro:wheel_v0 prefix="left" parent="base_link">
-    <origin xyz="0 0.14199 0.074742"  rpy="0 0 ${M_PI}" />
+    <origin xyz="0 0.142 0.074742" rpy="0 0 ${M_PI}" />
     <axis xyz="0 -1 0"/>
   </xacro:wheel_v0>
 

--- a/urdf/body/body.gazebo.xacro
+++ b/urdf/body/body.gazebo.xacro
@@ -5,7 +5,7 @@
       <selfCollide>false</selfCollide>
       <mu1>0.0</mu1>
       <mu2>0.0</mu2>
-      <kp>1000000.0</kp>
+      <kp>100000.0</kp>
       <kd>100.0</kd>
     </gazebo>
   </xacro:macro>

--- a/urdf/body/body.gazebo.xacro
+++ b/urdf/body/body.gazebo.xacro
@@ -3,8 +3,10 @@
   <xacro:macro name="base_gazebo_v0">
     <gazebo reference="base_link">
       <selfCollide>false</selfCollide>
-      <mu1 value="0.0" />
-      <mu2 value="0.0" />
+      <mu1>0.0</mu1>
+      <mu2>0.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
     </gazebo>
   </xacro:macro>
 </robot>

--- a/urdf/wheel/vwheel.urdf.xacro
+++ b/urdf/wheel/vwheel.urdf.xacro
@@ -22,8 +22,8 @@
         <xacro:if value="${prefix=='right'}">
           <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
         </xacro:if>
-        <xacro:if value="${prefix=='right'}">
-          <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
+        <xacro:if value="${prefix=='left'}">
+          <origin xyz="0 0 0" rpy="-${M_PI/2} 0 0"/>
         </xacro:if>
         <geometry>
           <mesh filename="file://$(find megarover_samples_ros2)/models/vmegarover/meshes/dae/vmega_wheel.dae"/>

--- a/urdf/wheel/vwheel.urdf.xacro
+++ b/urdf/wheel/vwheel.urdf.xacro
@@ -5,9 +5,8 @@
   <xacro:include filename="$(find megarover_samples_ros2)/urdf/wheel/wheel.gazebo.xacro"/>
 
   <xacro:property name="wheel_radius" value="0.076"/>
-  <xacro:property name="wheel_inertial_length" value="0.03"/>
-  <xacro:property name="wheel_collition_length" value="0.001"/>
-  <xacro:property name="wheel_mass" value="2.5"/>
+  <xacro:property name="wheel_length" value="0.03"/>
+  <xacro:property name="wheel_mass" value="0.823"/>
 
 
   <xacro:macro name="wheel_v0" params="prefix parent *joint_origin *joint_axis">
@@ -27,13 +26,13 @@
       <collision>
         <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <geometry>
-          <cylinder radius="${wheel_radius}" length="${wheel_collition_length}"/>
+          <cylinder radius="${wheel_radius}" length="${wheel_length}"/>
         </geometry>
       </collision>
       <inertial>
         <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <xacro:cylinder_inertial mass="${wheel_mass}"
-          radius="${wheel_radius}" length="${wheel_inertial_length}"/>
+          radius="${wheel_radius}" length="${wheel_length}"/>
       </inertial>
     </link>
   </xacro:macro>

--- a/urdf/wheel/vwheel.urdf.xacro
+++ b/urdf/wheel/vwheel.urdf.xacro
@@ -19,18 +19,22 @@
 
     <link name="${prefix}_wheel_link">
       <visual>
+        <xacro:if value="${prefix=='right'}">
+          <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
+        </xacro:if>
+        <xacro:if value="${prefix=='right'}">
+          <origin xyz="0 0 0" rpy="${M_PI/2} 0 0"/>
+        </xacro:if>
         <geometry>
           <mesh filename="file://$(find megarover_samples_ros2)/models/vmegarover/meshes/dae/vmega_wheel.dae"/>
         </geometry>
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <geometry>
           <cylinder radius="${wheel_radius}" length="${wheel_length}"/>
         </geometry>
       </collision>
       <inertial>
-        <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <xacro:cylinder_inertial mass="${wheel_mass}"
           radius="${wheel_radius}" length="${wheel_length}"/>
       </inertial>

--- a/urdf/wheel/vwheel.urdf.xacro
+++ b/urdf/wheel/vwheel.urdf.xacro
@@ -5,7 +5,8 @@
   <xacro:include filename="$(find megarover_samples_ros2)/urdf/wheel/wheel.gazebo.xacro"/>
 
   <xacro:property name="wheel_radius" value="0.076"/>
-  <xacro:property name="wheel_length" value="0.03"/>
+  <xacro:property name="wheel_inertial_length" value="0.03"/>
+  <xacro:property name="wheel_collition_length" value="0.001"/>
   <xacro:property name="wheel_mass" value="0.823"/>
 
 
@@ -26,13 +27,13 @@
       <collision>
         <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <geometry>
-          <cylinder radius="${wheel_radius}" length="${wheel_length}"/>
+          <cylinder radius="${wheel_radius}" length="${wheel_collition_length}"/>
         </geometry>
       </collision>
       <inertial>
         <origin xyz="0 0 0" rpy="${-M_PI/2} 0 0"/>
         <xacro:cylinder_inertial mass="${wheel_mass}"
-          radius="${wheel_radius}" length="${wheel_length}"/>
+          radius="${wheel_radius}" length="${wheel_inertial_length}"/>
       </inertial>
     </link>
   </xacro:macro>

--- a/urdf/wheel/vwheel.urdf.xacro
+++ b/urdf/wheel/vwheel.urdf.xacro
@@ -7,7 +7,7 @@
   <xacro:property name="wheel_radius" value="0.076"/>
   <xacro:property name="wheel_inertial_length" value="0.03"/>
   <xacro:property name="wheel_collition_length" value="0.001"/>
-  <xacro:property name="wheel_mass" value="0.823"/>
+  <xacro:property name="wheel_mass" value="2.5"/>
 
 
   <xacro:macro name="wheel_v0" params="prefix parent *joint_origin *joint_axis">

--- a/urdf/wheel/wheel.gazebo.xacro
+++ b/urdf/wheel/wheel.gazebo.xacro
@@ -6,7 +6,7 @@
       <selfCollide>false</selfCollide>
       <mu1>1.0</mu1>
       <mu2>1.0</mu2>
-      <kp>1000000.0</kp>
+      <kp>100000.0</kp>
       <kd>100.0</kd>
     </gazebo>
   </xacro:macro>

--- a/urdf/wheel/wheel.gazebo.xacro
+++ b/urdf/wheel/wheel.gazebo.xacro
@@ -4,8 +4,10 @@
   <xacro:macro name="wheel_gazebo_v0" params="prefix">
     <gazebo reference="${prefix}_wheel_link">
       <selfCollide>false</selfCollide>
-      <mu1 value="1.0" />
-      <mu2 value="1.0" />
+      <mu1>1.0</mu1>
+      <mu2>1.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
     </gazebo>
   </xacro:macro>
 </robot>


### PR DESCRIPTION
Relates: <https://github.com/atinfinity/megarover_samples_ros2/issues/24#issuecomment-2676117262>

- Enabled `odom_truth` for debugging
- Removed unnecessary joint_state_poblisher
- ~~Used `wheel_collision_length` to make the wheel (collision) narrower and thus prevent the contact points changes.~~
- ~~Additionally, the weight of the wheels was increased because the body itself sometimes drifted with fast stepping commands (with teleop).~~

---

Update: ref. <https://github.com/atinfinity/megarover_samples_ros2/issues/24#issuecomment-2677881322>

- Updated the rpy of the wheel joint/link.
  - In addition, `M_PI` which causes errors has been removed.